### PR TITLE
Count Clean Command

### DIFF
--- a/commands/channels/count.mjs
+++ b/commands/channels/count.mjs
@@ -9,22 +9,19 @@ export const command = {
     data: new SlashCommandBuilder()
         .setName('count')
         .setDescription('counting channel commands')
-        .addStringOption(option =>
-            option
-                .setName('option')
-                .setDescription('option')
-                .setRequired(true)
-                .addChoices({ name: 'Leaderboard', value: 'leaderboard' })
-                .addChoices({ name: 'Pins', value: 'pins' })
-        ),
+        .addSubcommand(subcommand => subcommand.setName('leaderboard'))
+        .addSubcommand(subcommand => subcommand.setName('pins')),
     async execute(interaction) {
         // Defer reply, need client so will be getting results from main function
         await interaction.deferReply();
         let embed = '';
-        if (interaction.options.getString('option') == 'leaderboard') {
-            embed = await getLeaderboard(interaction.client);
-        } else if (interaction.options.getString('option') == 'pins') {
-            embed = await getPinsLeaderboard(interaction.client);
+        switch(interaction.options.getSubcommand()) {
+            case 'leaderboard':
+                embed = await getLeaderboard(interaction.client);
+                break;
+            case 'pins':
+                embed = await getPinsLeaderboard(interaction.client);
+                break;
         }
         await interaction.editReply({ embeds: [embed] });
     },

--- a/commands/channels/count.mjs
+++ b/commands/channels/count.mjs
@@ -122,7 +122,6 @@ const cleanMessages = async function(client, commit) {
         'clean', 
         [
             {name: 'Mistakes Deleted', value: commit},
-            {name: ''}
         ]);
 }
 

--- a/commands/channels/count.mjs
+++ b/commands/channels/count.mjs
@@ -10,7 +10,13 @@ export const command = {
         .setName('count')
         .setDescription('counting channel commands')
         .addSubcommand(subcommand => subcommand.setName('leaderboard'))
-        .addSubcommand(subcommand => subcommand.setName('pins')),
+        .addSubcommand(subcommand => subcommand.setName('pins'))
+        .addSubcommand(subcommand => subcommand.setName('clean')
+            .addBooleanOption(option => 
+                option
+                    .setName('commit')
+                    .setRequired(false)
+                    .setDescription('Prints messages to remove when false. Deletes those messages when true.'))),
     async execute(interaction) {
         // Defer reply, need client so will be getting results from main function
         await interaction.deferReply();
@@ -21,6 +27,9 @@ export const command = {
                 break;
             case 'pins':
                 embed = await getPinsLeaderboard(interaction.client);
+                break;
+            case 'clean':
+                embed = await cleanMessages(interaction.client);
                 break;
         }
         await interaction.editReply({ embeds: [embed] });
@@ -139,4 +148,9 @@ const writeLastLeaderboardAndMessage = async function(leaderboard, messageId) {
         console.log('Error writing leaderboard and messages to output file');
         console.log(err);
     }
+}
+
+const cleanMessages = async function(client) {
+    messages = await getAllMessages(client, countingChannelId);
+
 }

--- a/commands/channels/count.mjs
+++ b/commands/channels/count.mjs
@@ -114,7 +114,13 @@ const cleanMessages = async function(client, commit) {
         }
     }
 
-    return buildLeaderboardEmbed(shameBoard, 'clean', {name: 'Messages Cleaned', value: commit});
+    return buildLeaderboardEmbed(
+        shameBoard, 
+        'clean', 
+        [
+            {name: 'Mistakes Deleted', value: commit},
+            {name: ''}
+        ]);
 }
 
 const sortMessagesIntoLeaderboard = async function(messages, leaderboard) {
@@ -136,10 +142,15 @@ const sortMessagesIntoLeaderboard = async function(messages, leaderboard) {
     return leaderboard;
 }
 
-const buildLeaderboardEmbed = async function(leaderboard, type, additionalFields={}) {
+const buildLeaderboardEmbed = async function(leaderboard, type, additionalFields=[]) {
+    let total = 0;
+    for (let i = 0; i < leaderboard.length; i++) {
+        total += leaderboard[i].value
+    }
+    
     // build columns
-    let leaders = ``;
-    let values = ``;
+    let leaders = `**Total**: \n`;
+    let values = `${total}\n`;
     let title = ``;
 
     for (let index = 1; index <= leaderboard.length; index++) {
@@ -161,20 +172,15 @@ const buildLeaderboardEmbed = async function(leaderboard, type, additionalFields
             title = 'Leaderboard';
     }
 
-    var embedBuilder = new EmbedBuilder()
+    return new EmbedBuilder()
         .setColor(0x0099FF)
         .setTitle(title)
         .addFields(
             { name: 'User', value: leaders, inline: true },
             { name: 'Value', value: values, inline: true },
         )
+        .addFields(additionalFields)
         .setTimestamp();
-
-    for (const [name, value] of Object.entries(additionalFields)) {
-        embedBuilder.addFields({name: name, value: value});
-    }
-
-    return embedBuilder;
 }
 
 const getLastLeaderboardAndMessage = async function() {

--- a/commands/channels/count.mjs
+++ b/commands/channels/count.mjs
@@ -101,16 +101,19 @@ const cleanMessages = async function(client, commit) {
     }
 
     shameBoard = sortMessagesIntoLeaderboard(mistakes, []);
-    for (let i = 0; i < mistakes.length; i++) {
-        if (commit) {
-            try {
-                console.log(`Deleting message ${mistakes[i].id}...`);
-                await mistakes[i].delete();
-            } catch(err) {  // continue removing other mistakes on single failures
-                console.log(err);
+    if (commit) {
+        try {
+            await fs.unlink(leaderboardFileLocation);
+            for (let i = 0; i < mistakes.length; i++) {
+                    console.log(`Deleting message ${mistakes[i].id}...`);
+                    await mistakes[i].delete();
             }
-        } else {
-            console.log(`Message ${mistakes[i].id} is invalid.`)
+        } catch(err) {
+            console.log(err);
+        }
+    } else {
+        for (let i = 0; i < mistakes.length; i++) {
+            console.log(`Mistake found in message ${mistakes[i].id}...`);
         }
     }
 


### PR DESCRIPTION
### Description

Adds the ability to clean the count-up discord channel by verifying all messages count up in order.

### Algorithm

- Accumulate messages and sort by timestamp.
- Iterate through messages until the first valid integer message is found. Track this value as the last known valid message.
- Iterate through remaining messages and check if their values equal the last known valid value plus one. If one does, track it as the last known valid value. If one doesn't, mark the message as a mistake.
  - Note: Non-integer messages are ignored. 
- Delete all known mistakes after each message has been checked.

### Subcommands

This PR also refactors the original count command options into subcommands. This was done to simplify the clean command and give it its own option.

### Extra Details

- Shames those who make mistakes by returning the 'Mistake Leaders' leaderboard.
- The `clean` subcommand has one option called `commit`. It defaults to false. When true, the mistaken messages are deleted; otherwise, they're just logged.
- Add total row to all leaderboard embed messages.