### PR TITLE
Refactor gemini options into subcommands.

### DIFF
--- a/commands/channels/gemini.mjs
+++ b/commands/channels/gemini.mjs
@@ -135,13 +135,14 @@ const chatCommand = async function(interaction) {
 }
 
 const listCommand = function() {
-    let embed = new EmbedBuilder().setTitle('Open Chat Sessions');
     let sessions = '';
     for (session in chatSessions) {
         sessions += `${session}\n`;
     }
 
-    return embed.setDescription(sessions);
+    return new EmbedBuilder()
+        .setTitle('Open Chat Sessions')
+        .setDescription(sessions);
 }
 
 const currentCommand = function(user) {

--- a/commands/channels/gemini.mjs
+++ b/commands/channels/gemini.mjs
@@ -55,8 +55,7 @@ export const command = {
             .setColor(0x0099FF)
             .setTitle(prompt)
             .setDescription(content)
-            .setAuthor({name: interaction.user.username})
-            .setFooter({text: `Chat ID: ${geminiChatId}`})
+            .setFooter({text: `Chat ID: ${geminiChatId}`});
 
         await interaction.editReply({embeds: [embedResponse]});
     },

--- a/commands/channels/gemini.mjs
+++ b/commands/channels/gemini.mjs
@@ -43,7 +43,7 @@ export const command = {
     async execute(interaction) {
         await interaction.deferReply();
 
-        let id = getChatId(interaction.user.username);
+        let id = getChatId(interaction);
         let model = interaction.options.getString('model') ?? defaultModel;
         let reset = interaction.options.getBoolean('reset') ?? false;
         let prompt = interaction.options.getString('prompt');
@@ -70,8 +70,9 @@ export const command = {
     },
 }
 
-const getChatId = function(user) {
+const getChatId = function(interaction) {
     let id = interaction.options.getString('id') ?? '';
+    let user = interaction.user.username;
     if (id !== ''){
         lastUserSessions[user] = id;
         return id;

--- a/commands/channels/gemini.mjs
+++ b/commands/channels/gemini.mjs
@@ -1,4 +1,4 @@
-import { SlashCommandBuilder, EmbedBuilder } from 'discord.js';
+import { SlashCommandBuilder, EmbedBuilder, Embed } from 'discord.js';
 import { GoogleAuth } from 'google-auth-library';
 import { VertexAI } from '@google-cloud/vertexai';
 
@@ -17,74 +17,68 @@ export const command = {
     data: new SlashCommandBuilder()
         .setName('gemini')
         .setDescription('Interact with Google\'s Gemini chat model.')
-        .addStringOption(option =>
-            option
-                .setName('prompt')
-                .setDescription('The prompt message.')
-                .setRequired(true)
-                .setMaxLength(maxPromptLength))
-        .addStringOption(option =>
-            option
-                .setName('id')
-                .setDescription(`The target chat session ID (default = ${defaultChatId}).`)
-                .setRequired(false)
-                .setMaxLength(maxIdLength))
-        .addStringOption(option =>
-            option
-                .setName('model')
-                .setDescription(`The Gemini model of the new chat session (default = ${defaultModel}).`)
-                .setRequired(false)
-                .addChoices({name: 'gemini-1.0-pro', value: 'gemini-1.0-pro'}))
-        .addBooleanOption(option =>
-            option
+        .addSubcommand(subcommand =>
+            subcommand
+                .setName('chat')
+                .setDescription('Chat with Google\'s Gemini chat model.')
+                .addStringOption(option =>
+                    option
+                        .setName('prompt')
+                        .setDescription('The prompt message.')
+                        .setRequired(true)
+                        .setMaxLength(maxPromptLength))
+                .addStringOption(option =>
+                    option
+                        .setName('id')
+                        .setDescription(`The target chat session ID (default = ${defaultChatId}).`)
+                        .setRequired(false)
+                        .setMaxLength(maxIdLength))
+                .addStringOption(option =>
+                    option
+                        .setName('model')
+                        .setDescription(`The Gemini model of the new chat session (default = ${defaultModel}).`)
+                        .setRequired(false)
+                        .addChoices({name: 'gemini-1.0-pro', value: 'gemini-1.0-pro'})))
+        .addSubcommand(subcommand =>
+            subcommand
+                .setName('list')
+                .setDescription('List the current chat sessions.'))
+        .addSubcommand(subcommand =>
+            subcommand
+                .setName('current')
+                .setDescription('Grab the last chat sessions you interacted with.'))
+        .addSubcommand(subcommand =>
+            subcommand
                 .setName('reset')
-                .setDescription('Reset the given chat session (default = false).')
-                .setRequired(false)),
+                .setDescription('Reset the given chat session.')
+                .addStringOption(option =>
+                    option
+                        .setName('id')
+                        .setDescription(`The target chat session ID.`)
+                        .setRequired(true))),
     async execute(interaction) {
         await interaction.deferReply();
 
-        let id = getChatId(interaction);
-        let model = interaction.options.getString('model') ?? defaultModel;
-        let reset = interaction.options.getBoolean('reset') ?? false;
-        let prompt = interaction.options.getString('prompt');
-        console.log('Gemini Prompt: ' + prompt);        
-
-        if (!(id in chatSessions) || reset) {
-            chatSessions[id] = {session: startChat(model), model: model};
+        let command = interaction.options.getSubcommand();
+        let response = new EmbedBuilder().setTitle('Invalid Command. Try again.');
+        switch(command) {
+            case 'chat':
+                response = chatCommand(interaction);
+                break;
+            case 'list':
+                response = listCommand();
+                break;
+            case 'current':
+                response = currentCommand(interaction.user.username);
+                break;
+            case 'reset':
+                response = resetCommand(interaction.options.getString('id'));
+                break;
         }
 
-        const response = await chatSessions[id]['session'].sendMessage(prompt);
-        let content = '';
-        for (const part of response.response.candidates[0].content.parts) {
-            content = content.concat('\n', part.text);
-        }
-        console.log('Gemini Response: ' + content);
-
-        let embedResponse = new EmbedBuilder()
-            .setColor(0x0099FF)
-            .setTitle(prompt)
-            .setDescription(content)
-            .setFooter({text: `Chat ID: ${id}  Model: ${chatSessions[id]['model']}`});
-
-        await interaction.editReply({embeds: [embedResponse]});
+        response.setColor(0x0099FF);
+        await interaction.editReply({embeds: [response]});
     },
-}
-
-const getChatId = function(interaction) {
-    let id = interaction.options.getString('id') ?? '';
-    let user = interaction.user.username;
-
-    if (id !== ''){
-        lastUserSessions[user] = id;
-        return id;
-    }
-
-    if (user in lastUserSessions) {
-        return lastUserSessions[user];
-    }
-
-    lastUserSessions[user] = defaultChatId;
-    return defaultChatId
 }
 
 const startChat = function(modelName) {
@@ -102,3 +96,73 @@ const startChat = function(modelName) {
     });
     return generativeModel.startChat({});
 };
+
+const getChatId = function(user, id='') {
+    if (id !== ''){
+        lastUserSessions[user] = id;
+        return id;
+    }
+
+    if (user in lastUserSessions) {
+        return lastUserSessions[user];
+    }
+
+    lastUserSessions[user] = defaultChatId;
+    return defaultChatId
+}
+
+const chatCommand = async function(interaction) {
+    let id = getChatId(interaction.user.username, interaction.options.getString('id') ?? '');
+    let model = interaction.options.getString('model') ?? defaultModel;
+    let prompt = interaction.options.getString('prompt');
+    console.log('Gemini Prompt: ' + prompt);        
+
+    if (!(id in chatSessions)) {
+        chatSessions[id] = {session: startChat(model), model: model};
+    }
+
+    const response = await chatSessions[id]['session'].sendMessage(prompt);
+    let content = '';
+    for (const part of response.response.candidates[0].content.parts) {
+        content = content.concat('\n', part.text);
+    }
+    console.log('Gemini Response: ' + content);
+
+    return new EmbedBuilder()
+        .setTitle(prompt)
+        .setDescription(content)
+        .setFooter({text: `Chat ID: ${id}  Model: ${chatSessions[id]['model']}`});
+}
+
+const listCommand = function() {
+    let embed = new EmbedBuilder().setTitle('Open Chat Sessions');
+    let sessions = '';
+    for (session in chatSessions) {
+        sessions += `${session}\n`;
+    }
+
+    return embed.setDescription(sessions);
+}
+
+const currentCommand = function(user) {
+    let lastChatId = defaultChatId;
+    if (user in lastUserSessions) {
+        lastChatId = lastUserSessions[user];
+    }
+
+    return new EmbedBuilder()
+        .setTitle(`${user}'s Current Chat`)
+        .setDescription(lastChatId)
+}
+
+const resetCommand = function(chatId) {
+    let msg = `Nothing to reset; ${chatId} doesn't exist.`;
+    if (chatId in chatSessions) {
+        delete chatSessions[chatId];
+        msg = 'Success!';
+    }
+
+    return new EmbedBuilder()
+        .setTitle(`Reset ${chatId}`)
+        .setDescription(msg);
+}

--- a/commands/channels/gemini.mjs
+++ b/commands/channels/gemini.mjs
@@ -1,4 +1,4 @@
-import { SlashCommandBuilder, EmbedBuilder, Embed } from 'discord.js';
+import { SlashCommandBuilder, EmbedBuilder } from 'discord.js';
 import { GoogleAuth } from 'google-auth-library';
 import { VertexAI } from '@google-cloud/vertexai';
 


### PR DESCRIPTION
- Add chat subcommand that encompasses the original gemini command.
- Add list subcommand that returns the IDs of all the open chats.
- Add current subcommand that returns the executing user's current chat ID.
- Break the original reset option into its own subcommand